### PR TITLE
feat: use tree packing for HTTP server responses (544KB → 32KB)

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -21,7 +21,10 @@ use serde::{Deserialize, Serialize};
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
-use inspire_pir::pir::{respond, respond_mmap, ClientQuery, EncodedDatabase, InspireCrs, MmapDatabase, ServerResponse};
+use inspire_pir::pir::{
+    respond_one_packing, respond_mmap_one_packing,
+    ClientQuery, EncodedDatabase, InspireCrs, MmapDatabase, ServerResponse,
+};
 
 #[derive(Parser)]
 #[command(name = "inspire-server")]
@@ -120,8 +123,8 @@ async fn handle_query(
     let start = Instant::now();
 
     let response = match &state.db {
-        DatabaseMode::InMemory(encoded_db) => respond(&state.crs, encoded_db, &query),
-        DatabaseMode::Mmap(mmap_db) => respond_mmap(&state.crs, mmap_db, &query),
+        DatabaseMode::InMemory(encoded_db) => respond_one_packing(&state.crs, encoded_db, &query),
+        DatabaseMode::Mmap(mmap_db) => respond_mmap_one_packing(&state.crs, mmap_db, &query),
     }
     .map_err(|e| {
         (

--- a/src/pir/mod.rs
+++ b/src/pir/mod.rs
@@ -66,5 +66,5 @@ pub use respond::{
     ServerResponse,
 };
 #[cfg(feature = "server")]
-pub use respond::respond_mmap;
+pub use respond::{respond_mmap, respond_mmap_one_packing};
 pub use setup::{setup, EncodedDatabase, InspireCrs, ServerCrs, ShardData};


### PR DESCRIPTION
## Summary

Reduces HTTP server response size from **544 KB to 32 KB** (17x reduction) by using tree packing.

## Changes

### Server
- Add `respond_mmap_one_packing()` for memory-mapped databases
- Update `server.rs` to use `respond_one_packing()` / `respond_mmap_one_packing()`

### Client
- Update `client.rs` to use `extract_with_variant(..., InspireVariant::OnePacking)`

### Documentation
- Update actual CRS sizes (~40-50 MB, not <10 MB)
- Clarify tree packing vs InspiRING 2-matrix approaches
- Fix Ethereum mapping format (Index is 8 bytes LE, not 4)
- Update CLI usage examples with correct flags

## Communication Cost Impact

| Variant | Before | After |
|---------|--------|-------|
| Response | 544 KB | 32 KB |
| Total (seeded) | 640 KB | 128 KB |

## Testing
```bash
cargo test --release one_packing
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches HTTP server to tree-packed responses (544KB→32KB), updates client to OnePacking extraction, and refreshes docs with packing details and actual CRS sizes.
> 
> - **Server**:
>   - Use tree packing for responses: replace `respond()`/`respond_mmap()` with `respond_one_packing()`/`respond_mmap_one_packing()` in `src/bin/server.rs`.
>   - Add `respond_mmap_one_packing()` in `src/pir/respond.rs` and export via `src/pir/mod.rs`.
> - **Client**:
>   - Switch extraction to `extract_with_variant(..., InspireVariant::OnePacking)` in `src/bin/client.rs` (single and batch paths).
> - **Docs**:
>   - Update `README.md`, `docs/COMMUNICATION_COSTS.md`, `docs/IMPLEMENTATION.md`, `docs/IMPLEMENTATION_COMPARISON.md`:
>     - Clarify packing approaches (tree packing default; InspiRING 2-matrix experimental) and response size drop to 32 KB.
>     - Note actual `ServerCrs` size (~40–50 MB) and components; correct Ethereum mapping formats (8-byte LE indices).
>     - Refresh CLI examples/flags and size formulas/tables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91aa15c6b03665e1c9882a6df67cc77279eb7d5a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated command-line interface with new flags for data directories, output options, and server binding configuration
  * Expanded protocol documentation with detailed specifications for communication costs, packing approaches, and server components
  * Added comprehensive examples and performance comparisons for different PIR variants

* **New Features**
  * Introduced multiple protocol variants with different packing strategies for optimized performance
  * Added support for memory-mapped database access for improved server efficiency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->