### PR TITLE
feat: use InspiRING packing by default for OnePacking/TwoPacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Default packing algorithm**: `respond_with_variant` for OnePacking/TwoPacking now uses InspiRING when `inspiring_packing_keys` is present in the query (~35x faster online), falling back to tree packing otherwise
+- **HTTP server**: Uses InspiRING for in-memory databases when packing keys are available
+- **Documentation**: Fixed performance claims ("226x faster" -> "~35x faster") and clarified CRS size comparison in protocol-visualization.html
+
 ### Added
 
 - **WASM Support**: Enable building for `wasm32-unknown-unknown` targets (browsers)

--- a/docs/protocol-visualization.html
+++ b/docs/protocol-visualization.html
@@ -599,7 +599,7 @@
                     Tree Packing (log d matrices)
                 </button>
                 <button id="show-inspiring-algo" class="algo-toggle" style="background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-color); padding: 0.5rem 1rem; border-radius: 4px; cursor: pointer; font-size: 0.85rem;">
-                    InspiRING (2 matrices) - 226x faster
+                    InspiRING (2 matrices) - ~35x faster
                 </button>
             </div>
 
@@ -682,7 +682,7 @@
                         <h4 style="color: var(--accent-orange); font-size: 0.9rem; margin-bottom: 0.5rem;">Performance (d=2048)</h4>
                         <p style="color: var(--text-secondary); font-size: 0.85rem; margin: 0;">
                             <strong>Keys:</strong> 2 matrices (K_g, K_h) vs 11<br>
-                            <strong>CRS size:</strong> 64 bytes vs 1056 KB (seeds only)<br>
+                            <strong>Packing keys:</strong> 64 bytes (seeds) vs 1056 KB (11 KS matrices)<br>
                             <strong>Online (16 LWEs):</strong> <span style="color: var(--accent-green);">115 μs</span><br>
                             <strong>Offline (16 LWEs):</strong> 6.1 ms (amortized)
                         </p>
@@ -727,8 +727,8 @@
                                 <td style="padding: 0.75rem; text-align: center; border-bottom: 1px solid var(--border-color);">5.5x</td>
                             </tr>
                             <tr>
-                                <td style="padding: 0.75rem; border-bottom: 1px solid var(--border-color);">CRS Key Material</td>
-                                <td style="padding: 0.75rem; text-align: center; border-bottom: 1px solid var(--border-color);">1056 KB</td>
+                                <td style="padding: 0.75rem; border-bottom: 1px solid var(--border-color);">Packing Key Material</td>
+                                <td style="padding: 0.75rem; text-align: center; border-bottom: 1px solid var(--border-color);">1056 KB (11 KS matrices)</td>
                                 <td style="padding: 0.75rem; text-align: center; border-bottom: 1px solid var(--border-color); color: var(--accent-green);">64 bytes (seeds)</td>
                                 <td style="padding: 0.75rem; text-align: center; border-bottom: 1px solid var(--border-color);">16,000x</td>
                             </tr>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,9 @@ pub mod modulus_switch;
 
 pub use pir::{
     setup, query, query_seeded, query_switched, 
-    respond, respond_with_variant, respond_one_packing,
+    respond, respond_with_variant, respond_one_packing, respond_inspiring,
     respond_seeded, respond_seeded_packed, respond_switched, respond_switched_packed,
+    respond_seeded_inspiring,
     extract, extract_with_variant,
     ServerCrs, InspireCrs, EncodedDatabase, ShardData,
     ClientQuery, ClientState, SeededClientQuery, SwitchedClientQuery, ServerResponse,
@@ -31,6 +32,6 @@ pub use pir::{
 };
 
 #[cfg(feature = "server")]
-pub use pir::{respond_mmap, MmapDatabase, save_shards_binary, load_shard_binary};
+pub use pir::{respond_mmap, respond_mmap_one_packing, MmapDatabase, save_shards_binary, load_shard_binary};
 
 pub use params::{InspireParams, InspireVariant, SecurityLevel};


### PR DESCRIPTION
## Summary

Switch InsPIRe^1/^2 to use InspiRING packing algorithm when `inspiring_packing_keys` is present in the query.

### Changes

- **respond_with_variant**: Uses InspiRING (~35x faster) when packing keys available, falls back to tree packing
- **HTTP server**: Prefers InspiRING for in-memory databases
- **Exports**: Added `respond_inspiring`, `respond_seeded_inspiring`, `respond_mmap_one_packing` to public API
- **Documentation**: 
  - Fixed performance claims (226x -> ~35x per current benchmarks)
  - Clarified CRS size comparison is for packing keys only

### Background

Tree packing uses log(d)=11 key-switching matrices and is from Google's baseline implementation.
InspiRING (from the InsPIRe paper) uses only 2 matrices and is ~35x faster online.

For seeded/switched queries, packing keys aren't available (they require the secret key), so tree packing remains the fallback.

### Testing

```
cargo test --test e2e_pir  # 11 passed, 1 ignored
cargo test --lib inspiring  # 40 passed
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prefer InspiRING packing when client packing keys are present (fallback to tree packing), update HTTP server to use it for in-memory DBs, and refresh docs/perf claims; add related exports.
> 
> - **PIR/Core**:
>   - `respond_with_variant`: selects `respond_inspiring` when `query.inspiring_packing_keys` is present; falls back to `respond_one_packing`.
>   - New/Exported APIs: `respond_inspiring`, `respond_seeded_inspiring`, and `respond_mmap_one_packing` added to public surface.
> - **HTTP Server (`src/bin/server.rs`)**:
>   - In-memory mode: uses `respond_inspiring` when packing keys are supplied; otherwise tree packing. Mmap mode remains tree packing.
> - **Docs/Changelog**:
>   - Update performance claim to "~35x faster" and clarify "Packing Key Material" vs CRS in `docs/protocol-visualization.html`.
>   - `CHANGELOG.md`: document default packing behavior change and server preference for InspiRING.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 609cc339b9437cb8b547164287ffd122f4c40d48. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default packing algorithm now intelligently selects InspiRING when packing keys are available; otherwise uses tree packing fallback.
  * HTTP server leverages InspiRING for in-memory databases when packing keys are present.

* **Documentation**
  * Updated performance benchmarks and clarified terminology around packing keys and key material.
  * Revised performance claims with more accurate metrics and timing data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->