### PR TITLE
fix: address remaining visualization issues from issue #31

### DIFF
--- a/docs/protocol-visualization.html
+++ b/docs/protocol-visualization.html
@@ -1889,7 +1889,7 @@
                 .attr("y", 25)
                 .attr("fill", COLORS.textSecondary)
                 .attr("font-size", "12px")
-                .text(`Total: ${numShards.toLocaleString()} shards | Target shard (implicitly selected by encrypted query): ${currentTargetShard}`);
+                .text(`Total: ${numShards.toLocaleString()} shards | Target shard (selected by query; may be sent as metadata): ${currentTargetShard}`);
 
             // Shard grid
             const gridY = 45;


### PR DESCRIPTION
## Summary

Fixes remaining issues in `protocol-visualization.html` found by Codex (GPT-5.2) review.

Related to #31

## Changes

### 1. Remove incorrect 'CONSTANT' claim (lines 762, 786)
- **Before**: "Query and response sizes are CONSTANT regardless of database size"
- **After**: "Query size scales with N/t (indicator vector length). Response size scales with entry size."
- Annotation row updated from "O(d) - Constant!" to "O(N/t) query, O(entry) response"

### 2. Fix SVG accessibility desc (line 424)
- **Before**: "Query (RGSW ciphertext)" - wrong for InsPIRe_0 and InsPIRe^(2) which don't use RGSW
- **After**: "Query (LWE indicator, optionally with RGSW for InsPIRe)"

### 3. Fix privacy-concerning shard_id text (line 1892)
- **Before**: "Query contains shard_id" - implies plaintext shard selection
- **After**: "Target shard (encrypted in query)" - correctly indicates encryption

## Review
- Codex review identified these issues
- All three are documentation/text fixes, no code logic changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies protocol visualization text without changing any logic.
> 
> - **Accessibility/SVG:** Update `desc` to reflect cross-variant query format: `LWE` indicator with optional `RGSW` (InsPIRe only)
> - **Size semantics:** Replace incorrect "CONSTANT" claim with scaling note: query `O(N/t)`, response `O(entry)`; update table annotation accordingly
> - **Privacy wording:** Change shard text from "Query contains shard_id" to "Target shard (encrypted in query)"
> 
> All edits are documentation/text in `docs/protocol-visualization.html`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d46b208720a281599666f9103348a8a21c55b58. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified protocol: queries use LWE indicators with optional RGSW for InsPIRe.
  * Updated communication-size guidance: queries scale with N/t (indicator length); responses scale with entry size (noted as O(N/t) query, O(entry) response).
  * Revised shard wording: target shard is selected by the query and may be included as metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->