### PR TITLE
docs/tests: note switched+OnePacking limitation

### DIFF
--- a/src/pir/respond.rs
+++ b/src/pir/respond.rs
@@ -442,6 +442,10 @@ pub fn respond_switched(
 /// PIR.Respond with switched+seeded query using OnePacking
 ///
 /// Maximum compression variant: 75% query reduction + 16x response reduction.
+///
+/// NOTE: With current default parameters, switched+OnePacking is not
+/// correctness-safe due to noise amplification. Prefer `respond_switched`
+/// (no packing) until parameters are updated.
 pub fn respond_switched_packed(
     crs: &ServerCrs,
     encoded_db: &EncodedDatabase,


### PR DESCRIPTION
## Summary
- add a warning in `respond_switched_packed` docs about switched+OnePacking correctness
- add an ignored e2e test that reproduces the failure (for future regression)

## Context
Switched queries are correct with NoPacking, but fail when combined with OnePacking at default params; see #41.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Docs:**
> - Warns in `respond_switched_packed` that switched+OnePacking is currently not correctness-safe due to noise amplification; recommend using `respond_switched` (no packing) for now.
> 
> **Tests:**
> - Adds ignored e2e test `test_e2e_switched_query_default_params_one_packing` in `tests/e2e_pir.rs` that reproduces the switched+OnePacking failure under default/production-like parameters (kept as a future regression check).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90325bc6c30f65065e744d26b8ff79eafdf95ef0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added advisory notes for a specific configuration option, indicating current limitations with default parameters. Guidance provided for alternative approaches until future updates address parameter optimization.

* **Tests**
  * Added regression test to validate configuration behavior following planned parameter improvements. Test marked for activation upon implementation of future updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->